### PR TITLE
fix: bounced all modules to latest verion in usages

### DIFF
--- a/examples/gateway/main.tf
+++ b/examples/gateway/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -12,14 +12,14 @@ module "rg" {
   groups = {
     demo = {
       name     = module.naming.resource_group.name_unique
-      location = "germanywestcentral"
+      location = "westeurope"
     }
   }
 }
 
 module "network" {
   source  = "cloudnationhq/vnet/azure"
-  version = "~> 4.0"
+  version = "~> 8.0"
 
   naming = local.naming
 
@@ -27,12 +27,12 @@ module "network" {
     name           = module.naming.virtual_network.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    cidr           = ["10.19.0.0/16"]
+    address_space  = ["10.19.0.0/16"]
 
     subnets = {
       private = {
-        cidr = ["10.19.1.0/24"]
-        nsg  = {}
+        address_prefixes       = ["10.19.1.0/24"]
+        network_security_group = {}
       }
     }
   }
@@ -43,7 +43,7 @@ module "lb" {
   version = "~> 1.0"
 
   config = {
-    name           = module.naming.lb.name
+    name           = module.naming.lb.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
     sku            = "Gateway"

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -26,7 +26,7 @@ module "network" {
     name           = module.naming.virtual_network.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    address_space  = ["11.19.0.0/16"]
+    address_space  = ["10.19.0.0/16"]
   }
 }
 

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -12,21 +12,21 @@ module "rg" {
   groups = {
     demo = {
       name     = module.naming.resource_group.name_unique
-      location = "germanywestcentral"
+      location = "westeurope"
     }
   }
 }
 
 module "network" {
   source  = "cloudnationhq/vnet/azure"
-  version = "~> 4.0"
+  version = "~> 8.0"
   naming  = local.naming
 
   vnet = {
     name           = module.naming.virtual_network.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    cidr           = ["10.19.0.0/16"]
+    address_space  = ["11.19.0.0/16"]
   }
 }
 
@@ -48,7 +48,7 @@ module "lb" {
   version = "~> 1.0"
 
   config = {
-    name           = module.naming.lb.name
+    name           = module.naming.lb.name_unique
     resource_group = module.rg.groups.demo.name
     location       = module.rg.groups.demo.location
     sku            = "Standard"


### PR DESCRIPTION
## Description

This PR increments all modules in usages to the latest. All deployment tests will succeed now..

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)